### PR TITLE
Don't skip Python 3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
     number: 0
-    skip: True  # [py35 and win]
 
 requirements:
     build:


### PR DESCRIPTION
The only thing that worries me is that I could not get geos to compile on Windows and Python 3.5 using features. See https://github.com/conda-forge/geos-feedstock/pull/5#issuecomment-201940475