### PR TITLE
Update to 0.14.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
-{% set version = "0.14.1" %}
+{% set version = "0.14.2" %}
 
 package:
     name: cartopy
     version: {{ version }}
 
 source:
-    git_url: https://github.com/SciTools/cartopy.git
-    git_tag: v{{ version }}
-    md5: 021a13f625ce71b6040fcddc8727336c
+    fn: cartopy-{{ version }}.tar.gz
+    url: https://github.com/SciTools/cartopy/archive/v{{ version }}.tar.gz
+    sha256: 7ee4d38871b742cdde22f1982a10619bbe103c63575364988bd0be9c0ba57b6e
     patches:
         - cartopy.win.patch  # [win]
 


### PR DESCRIPTION
Downloading a tarball instead of a git clone and using `sha256` instead of `md5`.