### PR TITLE
NO MRG: Try skipping CircleCI builds (no-op)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,11 @@ install:
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
-
-      conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
 
 script:
   - conda build ./recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,12 +94,8 @@ install:
     - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels conda-forge
-    - cmd: conda info
-    - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
-    # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: Remove once there is a release that fixes the upstream issue
-    # ( https://github.com/conda/conda-build/issues/895 ).
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
+    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -39,9 +39,8 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda update --yes --all
-conda install --yes conda-build
-conda info
+conda install --yes --quiet conda-forge-build-setup
+source run_conda_forge_build_setup
 
 # Embarking on 6 case(s).
     set -x


### PR DESCRIPTION
This is a test only PR. Do not merge it.

Tries to re-render with a development version of `conda-smithy` to test skipping CircleCI builds when they are not needed. Basically, this will be a no-op. Thus it should be the same as PR ( https://github.com/conda-forge/cartopy-feedstock/pull/11 ).

cc @pelson