### PR TITLE
Test geos 3.5.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ conda search cartopy --channel conda-forge
 ```
 
 
-
 About conda-forge
 =================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
@@ -14,6 +12,8 @@ environment:
   # We set a default Python version for the miniconda that is to be installed. This can be
   # overridden in the matrix definition where appropriate.
   CONDA_PY: "27"
+  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -22,50 +22,62 @@ environment:
     - TARGET_ARCH: x86
       CONDA_NPY: 110
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_NPY: 110
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 110
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_NPY: 110
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 110
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_NPY: 110
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -86,24 +98,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,43 +12,41 @@ source:
     - cartopy.win.patch  # [win]
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
     - python
     - setuptools
-    - six
+    - msinttypes  # [win]
     - numpy x.x
     - cython
+    - geos 3.5.*
     - proj4 4.9.3
-    - geos 3.4.*
-    - shapely >=1.5.6
-    - owslib
-    - pyshp
-    - pyepsg
-    - msinttypes  # [win]
   run:
     - python
+    - numpy x.x
     - six
-    - mock
-    - nose
     - pillow
     - owslib
-    - numpy x.x
     - proj4 4.9.3
-    - shapely >=1.5.6
+    - geos 3.5.*
+    - shapely
     - scipy
     - pyshp
     - matplotlib
     - pyepsg
 
 test:
+  requires:
+    - nose
+    - pep8
   imports:
     - cartopy
     - cartopy.mpl.geoaxes
     - cartopy.crs
   commands:
+    - nosetests cartopy --with-doctest -sv  # [linux]
     #- conda inspect linkages -p $PREFIX cartopy  # [not win]
     #- conda inspect objects -p $PREFIX cartopy  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,6 @@ test:
     - cartopy.mpl.geoaxes
     - cartopy.crs
   commands:
-    - nosetests cartopy --with-doctest -sv  # [linux]
     #- conda inspect linkages -p $PREFIX cartopy  # [not win]
     #- conda inspect objects -p $PREFIX cartopy  # [osx]
 


### PR DESCRIPTION
Should not work until we merge https://github.com/conda-forge/shapely-feedstock/pull/13

This PR,
-  pins `geos` at `build` and `run` time to help `conda` do the right thing;
- unpin `shapely` as `>=1.5.6` that is not a limit to build `cartopy` but a remnant from old attempts to control the geos version (I may be wrong here);
- clean up the build dependencies a little bit making it easier to identify those that are needed for the cythin extensions;
- run `nosetests` to check if `geos 3.5.1` is OK.

The last one will probably fail and we will need to remove it but maybe we can catch something that may be due to the `geos` change.