### PR TITLE
New build for OSX

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - matplotlib2.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
Since 3 days ago, cartopy from conda-forge breaks python. Consider the following example

```bash
wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
bash miniconda.sh -p miniconda3 -b
export PATH=`pwd`/miniconda3/bin:$PATH
conda install -c conda-forge cartopy -y
python -c "import cartopy"
```
The last command prints the following to stdout
```
Invalid argument (must be a Polygon)
Geometry must be a Point or LineString
Assertion failed: (0 != cs), function GEOSCoordSeq_getSize_r, file geos_ts_c.cpp, line 3797.
Abort trap: 6
```
Since the anaconda token has been updated recently, this PR intends to trigger a new build on OSX. Maybe this already solves the problem.