### PR TITLE
Remove the default linewidth as 1.0

### DIFF
--- a/recipe/matplotlib2.patch
+++ b/recipe/matplotlib2.patch
@@ -6,7 +6,6 @@ index 7cce646..524b646 100644
              # was removed after mpl v1.2.0, so the hard-coded value of 1 is
              # used instead.
              self.set_zorder(1)
-+        self._kwargs.setdefault('linewidth', 1.0)
  
          self._feature = feature
  

--- a/recipe/matplotlib2.patch
+++ b/recipe/matplotlib2.patch
@@ -1,14 +1,3 @@
-diff --git a/lib/cartopy/mpl/feature_artist.py b/lib/cartopy/mpl/feature_artist.py
-index 7cce646..524b646 100644
---- a/lib/cartopy/mpl/feature_artist.py
-+++ b/lib/cartopy/mpl/feature_artist.py
-@@ -108,6 +108,7 @@ class FeatureArtist(matplotlib.artist.Artist):
-             # was removed after mpl v1.2.0, so the hard-coded value of 1 is
-             # used instead.
-             self.set_zorder(1)
- 
-         self._feature = feature
- 
 diff --git a/lib/cartopy/mpl/gridliner.py b/lib/cartopy/mpl/gridliner.py
 index 1932745..42ee019 100644
 --- a/lib/cartopy/mpl/gridliner.py


### PR DESCRIPTION
Linewidth is unchangable when using `ax.add_geometries(..., linewidth=0.5, ...)`.