### PR TITLE
Change to depend on matplotlib-base

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: True  # [win and vc<14]
-  number: 1006
+  number: 1007
 
 requirements:
   build:
@@ -38,7 +38,7 @@ requirements:
     - shapely
     - scipy
     - pyshp
-    - matplotlib
+    - matplotlib-base
     - pyepsg
     - pykdtree
 


### PR DESCRIPTION
We don't *require* the GUI, so don't depend on matplotlib, just
matplotlib-base. Right now, matplotlib (depends on pyqt) cannot install
next to sharppy (depends on pyside2). This will probably be fine once
qt 5.12 builds of pyqt are available.

I skipped rerendering because that removed some proj4 pinning, and I don't want to cope with whether that's correct right now.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
