### PR TITLE
remove un-needed openssl pinning

### DIFF
--- a/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
@@ -18,8 +18,6 @@ geos:
 - 3.9.1
 numpy:
 - '1.18'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
@@ -18,8 +18,6 @@ geos:
 - 3.9.1
 numpy:
 - '1.18'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
@@ -18,8 +18,6 @@ geos:
 - 3.9.1
 numpy:
 - '1.19'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -18,8 +18,6 @@ geos:
 - 3.9.1
 numpy:
 - '1.19'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
@@ -18,8 +18,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.18'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
@@ -18,8 +18,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.18'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
@@ -18,8 +18,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -18,8 +18,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -18,8 +18,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
 - '1.19'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -18,8 +18,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
 - '1.19'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.18python3.7.____cpython.yaml
@@ -10,8 +10,6 @@ geos:
 - 3.9.1
 numpy:
 - '1.18'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.18python3.8.____cpython.yaml
@@ -10,8 +10,6 @@ geos:
 - 3.9.1
 numpy:
 - '1.18'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/win_64_numpy1.19python3.7.____73_pypy.yaml
@@ -10,8 +10,6 @@ geos:
 - 3.9.1
 numpy:
 - '1.19'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
@@ -10,8 +10,6 @@ geos:
 - 3.9.1
 numpy:
 - '1.19'
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   error_overlinking: true
-  number: 0
+  number: 1
    # compatible proj and pyproj are only available for py>=37
   skip: true  # [py<37]
 
@@ -32,8 +32,6 @@ requirements:
     - numpy
     - proj
     - geos
-    # make openssl an explicit dependency because we're having trouble with >=3
-    - openssl
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -46,8 +44,6 @@ requirements:
     - matplotlib-base >=3.1
     - scipy >=0.10
     - ucrt  # [win]
-    # make openssl an explicit dependency because we're having trouble with >=3
-    - openssl
 
 test:
   imports:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The workaround for openssl done in #125 should no longer be necessary given conda-forge/python-feedstock#517